### PR TITLE
fix: 노출된 패스워드 제거

### DIFF
--- a/src/http/AuthUser.http
+++ b/src/http/AuthUser.http
@@ -1,14 +1,14 @@
 ### 로그인
-GET {{url}}/auth/login?userId=fredg@hogwarts.owl&password=grifrules
+GET {{url}}/auth/login?userId=&password=
 
 ### 회원가입
 POST {{url}}/auth/sign-in
 Content-Type: application/json
 
 {
-  "userId": "fredg@hogwarts.owl",
-  "password": "grifrules",
-  "confirmPassword": "grifrules",
+  "userId": "",
+  "password": "",
+  "confirmPassword": "",
   "username": "iamGeorge",
   "firstName": "Fred",
   "lastName": "Weasley"


### PR DESCRIPTION
패스워드 노출로 git guardian에서 이메일 수신함
테스트용 계정이긴 하지만 보안은 실서비스를 다루는 것처럼 관리하는게 좋다고 생각함