### PR TITLE
Feature/refresh token request

### DIFF
--- a/src/http/Auth.http
+++ b/src/http/Auth.http
@@ -1,5 +1,5 @@
 ### 로그인
-GET {{url}}/auth/login
+POST {{url}}/auth/login
 Content-Type: application/json
 
 {
@@ -18,4 +18,14 @@ Content-Type: application/json
   "username": "",
   "firstName": "",
   "lastName": ""
+}
+
+### 로그인 갱신
+POST {{url}}/auth/refresh
+Content-Type: application/json
+X-Refresh-Token:
+
+{
+  "userId": "",
+  "password": ""
 }

--- a/src/http/User.http
+++ b/src/http/User.http
@@ -8,9 +8,9 @@ Content-Type: application/json
 Authorization: Bearer
 
 {
-  "username": "plantLoverBoy",
-  "firstName": "Neville",
-  "lastName": "Longbottom"
+  "username": "",
+  "firstName": "",
+  "lastName": ""
 }
 
 ### 유저 업데이트
@@ -19,9 +19,9 @@ Content-Type: application/json
 Authorization: Bearer
 
 {
-  "username": "BestChestKing1",
-  "firstName": "Ron",
-  "lastName": "Weasley"
+  "username": "",
+  "firstName": "",
+  "lastName": ""
 }
 
 ### 유저 삭제

--- a/src/main/java/com/bluetoya/taradiddle/common/config/MongoConfig.java
+++ b/src/main/java/com/bluetoya/taradiddle/common/config/MongoConfig.java
@@ -1,0 +1,62 @@
+package com.bluetoya.taradiddle.common.config;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+
+@Slf4j
+@Configuration
+public class MongoConfig {
+
+    @Value("${spring.data.mongodb.database}")
+    private String database;
+
+    @Value("${spring.data.mongodb.pool-min-size}")
+    private int poolMinSize;
+
+    @Value("${spring.data.mongodb.pool-max-size}")
+    private int poolMaxSize;
+
+    @Value("${spring.data.mongodb.connection-time-out}")
+    private int connectionTimeOut;
+
+    @Value("${spring.data.mongodb.max-wait-time}")
+    private int maxWaitTime;
+
+    @Value("${spring.data.mongodb.read-time-out}")
+    private int readTimeOut;
+
+    @Bean
+    public MongoClient mongoClient(@Value("${spring.data.mongodb.uri}") String uri) {
+        return MongoClients.create(MongoClientSettings.builder()
+            .applyConnectionString(new ConnectionString(uri))
+            .applyToConnectionPoolSettings(builder ->
+                builder.maxSize(poolMaxSize)
+                    .minSize(poolMinSize)
+                    .maxWaitTime(maxWaitTime, TimeUnit.SECONDS))
+            .applyToSocketSettings(builder ->
+                builder.connectTimeout(connectionTimeOut, TimeUnit.SECONDS)
+                    .readTimeout(readTimeOut, TimeUnit.SECONDS))  // 읽기 타임아웃
+            .build());
+    }
+
+    @Bean
+    public MongoDatabaseFactory mongoDatabaseFactory(MongoClient mongoClient) {
+        return new SimpleMongoClientDatabaseFactory(mongoClient, database);
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate(MongoDatabaseFactory mongoDatabaseFactory) {
+        return new MongoTemplate(mongoDatabaseFactory);
+    }
+
+}

--- a/src/main/java/com/bluetoya/taradiddle/common/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/bluetoya/taradiddle/common/exception/errorcode/AuthErrorCode.java
@@ -16,6 +16,7 @@ public enum AuthErrorCode implements ErrorCode {
     NEED_VARIOUS_CHARACTERS(HttpStatus.BAD_REQUEST, "패스워드에 소문자, 대문자, 숫자가 하나씩 들어가 있어야 합니다."),
     USER_ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
     WRONG_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "존재하지 않거나 만료된 엑세스 토큰입니다."),
+    WRONG_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "존재하지 않거나 만료된 리프레시 토큰입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bluetoya/taradiddle/common/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/bluetoya/taradiddle/common/filter/JwtAuthorizationFilter.java
@@ -25,10 +25,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
         throws ServletException, IOException {
 
-        if (request.getRequestURI().equals("/auth/login")) {
-            filterChain.doFilter(request, response);
-        }
-
         String token = getTokenFromRequest(request);
 
         if (Objects.nonNull(token)) {

--- a/src/main/java/com/bluetoya/taradiddle/common/security/SecurityConfig.java
+++ b/src/main/java/com/bluetoya/taradiddle/common/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(
                 requests -> requests
-                    .requestMatchers("/auth/login", "/auth/sign-in", "/error/**").permitAll()
+                    .requestMatchers("/auth/login", "/auth/sign-in", "/auth/refresh", "/error/**").permitAll()
                     .anyRequest().authenticated())
             .formLogin(AbstractHttpConfigurer::disable)
             .logout(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/controller/AuthController.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/controller/AuthController.java
@@ -17,7 +17,7 @@ public class AuthController {
 
     private final AuthenticationService authenticationService;
 
-    @GetMapping("/login")
+    @PostMapping("/login")
     public ApiResponse<LoginResponse> login(final @RequestBody LoginRequest request, HttpServletResponse response) {
         return new ApiResponse<>(authenticationService.login(request, response));
     }

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/controller/AuthenticationController.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/controller/AuthenticationController.java
@@ -6,6 +6,7 @@ import com.bluetoya.taradiddle.feature.auth.dto.AuthResponse;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInRequest;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInResponse;
 import com.bluetoya.taradiddle.feature.auth.service.AuthenticationService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -28,8 +29,8 @@ public class AuthenticationController {
     }
 
     @PostMapping("/refresh")
-    public ApiResponse<AuthResponse> refresh(final @RequestBody AuthRequest request, HttpServletResponse response) {
-        return new ApiResponse<>(authenticationService.refresh(request, response));
+    public ApiResponse<AuthResponse> refresh(final @RequestBody AuthRequest authRequest, HttpServletRequest request, HttpServletResponse response) {
+        return new ApiResponse<>(authenticationService.refresh(authRequest, request, response));
     }
 
 }

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/controller/AuthenticationController.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/controller/AuthenticationController.java
@@ -1,8 +1,8 @@
 package com.bluetoya.taradiddle.feature.auth.controller;
 
 import com.bluetoya.taradiddle.common.ApiResponse;
-import com.bluetoya.taradiddle.feature.auth.dto.LoginRequest;
-import com.bluetoya.taradiddle.feature.auth.dto.LoginResponse;
+import com.bluetoya.taradiddle.feature.auth.dto.AuthRequest;
+import com.bluetoya.taradiddle.feature.auth.dto.AuthResponse;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInRequest;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInResponse;
 import com.bluetoya.taradiddle.feature.auth.service.AuthenticationService;
@@ -13,18 +13,23 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
-public class AuthController {
+public class AuthenticationController {
 
     private final AuthenticationService authenticationService;
 
     @PostMapping("/login")
-    public ApiResponse<LoginResponse> login(final @RequestBody LoginRequest request, HttpServletResponse response) {
+    public ApiResponse<AuthResponse> login(final @RequestBody AuthRequest request, HttpServletResponse response) {
         return new ApiResponse<>(authenticationService.login(request, response));
     }
 
     @PostMapping("/sign-in")
     public ApiResponse<SignInResponse> signIn(final @RequestBody SignInRequest request) {
         return new ApiResponse<>(authenticationService.signIn(request));
+    }
+
+    @PostMapping("/refresh")
+    public ApiResponse<AuthResponse> refresh(final @RequestBody AuthRequest request, HttpServletResponse response) {
+        return new ApiResponse<>(authenticationService.refresh(request, response));
     }
 
 }

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/dto/AuthRequest.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/dto/AuthRequest.java
@@ -1,0 +1,5 @@
+package com.bluetoya.taradiddle.feature.auth.dto;
+
+public record AuthRequest(String userId, String password) {
+
+}

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/dto/AuthResponse.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/dto/AuthResponse.java
@@ -1,5 +1,5 @@
 package com.bluetoya.taradiddle.feature.auth.dto;
 
-public record LoginResponse(String message) {
+public record AuthResponse(String message) {
 
 }

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/dto/LoginRequest.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/dto/LoginRequest.java
@@ -1,5 +1,0 @@
-package com.bluetoya.taradiddle.feature.auth.dto;
-
-public record LoginRequest(String userId, String password) {
-
-}

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/entity/Auth.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/entity/Auth.java
@@ -17,6 +17,7 @@ public class Auth {
     private String userId;
     private String password;
     private LocalDateTime signInDate;
+    private String refreshToken;
 
     public static Auth of(String userId, String password) {
         return Auth.builder().userId(userId).password(password).signInDate(DateUtil.now())

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/repository/AuthCustomRepository.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/repository/AuthCustomRepository.java
@@ -1,0 +1,6 @@
+package com.bluetoya.taradiddle.feature.auth.repository;
+
+public interface AuthCustomRepository {
+
+    void saveRefreshToken(String userId, String refreshToken);
+}

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/repository/AuthCustomRepositoryImpl.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/repository/AuthCustomRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.bluetoya.taradiddle.feature.auth.repository;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+import static org.springframework.data.mongodb.core.query.Update.update;
+
+import com.bluetoya.taradiddle.feature.auth.entity.Auth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AuthCustomRepositoryImpl implements AuthCustomRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public void saveRefreshToken(String userId, String refreshToken) {
+        mongoTemplate.updateFirst(query(where("userId").is(userId)),
+            update("refreshToken", refreshToken), Auth.class);
+    }
+}

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/repository/AuthRepository.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/repository/AuthRepository.java
@@ -4,7 +4,7 @@ import com.bluetoya.taradiddle.feature.auth.entity.Auth;
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface AuthRepository extends MongoRepository<Auth, String> {
+public interface AuthRepository extends MongoRepository<Auth, String>, AuthCustomRepository {
 
     Optional<Auth> findByUserId(String userId);
 }

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationService.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationService.java
@@ -4,6 +4,7 @@ import com.bluetoya.taradiddle.feature.auth.dto.AuthRequest;
 import com.bluetoya.taradiddle.feature.auth.dto.AuthResponse;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInRequest;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthenticationService {
@@ -12,5 +13,5 @@ public interface AuthenticationService {
 
     SignInResponse signIn(SignInRequest request);
 
-    AuthResponse refresh(AuthRequest request, HttpServletResponse response);
+    AuthResponse refresh(AuthRequest authRequest, HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationService.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationService.java
@@ -1,15 +1,16 @@
 package com.bluetoya.taradiddle.feature.auth.service;
 
-import com.bluetoya.taradiddle.feature.auth.dto.LoginRequest;
-import com.bluetoya.taradiddle.feature.auth.dto.LoginResponse;
+import com.bluetoya.taradiddle.feature.auth.dto.AuthRequest;
+import com.bluetoya.taradiddle.feature.auth.dto.AuthResponse;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInRequest;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInResponse;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthenticationService {
 
-    LoginResponse login(LoginRequest request, HttpServletResponse response);
+    AuthResponse login(AuthRequest request, HttpServletResponse response);
 
     SignInResponse signIn(SignInRequest request);
 
+    AuthResponse refresh(AuthRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationServiceImpl.java
@@ -34,7 +34,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         String accessToken = jwtProvider.generateAccessToken(request.userId());
         String refreshToken = jwtProvider.generateRefreshToken(request.userId());
 
-        // TODO :: db에 refresh token insert
+        authRepository.saveRefreshToken(request.userId(), refreshToken);
 
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("X-Refresh-Token", refreshToken);

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationServiceImpl.java
@@ -2,8 +2,8 @@ package com.bluetoya.taradiddle.feature.auth.service;
 
 import com.bluetoya.taradiddle.common.security.JwtProvider;
 import com.bluetoya.taradiddle.feature.auth.dto.AuthDto;
-import com.bluetoya.taradiddle.feature.auth.dto.LoginRequest;
-import com.bluetoya.taradiddle.feature.auth.dto.LoginResponse;
+import com.bluetoya.taradiddle.feature.auth.dto.AuthRequest;
+import com.bluetoya.taradiddle.feature.auth.dto.AuthResponse;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInRequest;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInResponse;
 import com.bluetoya.taradiddle.feature.user.UserDto;
@@ -28,7 +28,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     private final SignInValidator validator;
 
     @Override
-    public LoginResponse login(LoginRequest request, HttpServletResponse response) {
+    public AuthResponse login(AuthRequest request, HttpServletResponse response) {
         validator.validateLogin(request);
 
         String accessToken = jwtProvider.generateAccessToken(request.userId());
@@ -37,7 +37,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("X-Refresh-Token", refreshToken);
 
-        return new LoginResponse("로그인 성공했습니다.");
+        return new AuthResponse("로그인 성공했습니다.");
     }
 
     @Override
@@ -50,5 +50,10 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         User user = userRepository.save(User.of(request, auth.getId()));
 
         return new SignInResponse(AuthDto.from(auth), UserDto.from(user));
+    }
+
+    @Override
+    public AuthResponse refresh(AuthRequest request, HttpServletResponse response) {
+        return null;
     }
 }

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/service/AuthenticationServiceImpl.java
@@ -34,6 +34,8 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         String accessToken = jwtProvider.generateAccessToken(request.userId());
         String refreshToken = jwtProvider.generateRefreshToken(request.userId());
 
+        // TODO :: db에 refresh token insert
+
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("X-Refresh-Token", refreshToken);
 
@@ -54,6 +56,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
     @Override
     public AuthResponse refresh(AuthRequest request, HttpServletResponse response) {
+        // TODO :: refresh token 값 비교 후 일치하면 access token과 refresh token 재 생성해서 header에 넣어 보내기
         return null;
     }
 }

--- a/src/main/java/com/bluetoya/taradiddle/feature/auth/validator/SignInValidator.java
+++ b/src/main/java/com/bluetoya/taradiddle/feature/auth/validator/SignInValidator.java
@@ -2,7 +2,7 @@ package com.bluetoya.taradiddle.feature.auth.validator;
 
 import com.bluetoya.taradiddle.common.exception.CustomException;
 import com.bluetoya.taradiddle.common.exception.errorcode.AuthErrorCode;
-import com.bluetoya.taradiddle.feature.auth.dto.LoginRequest;
+import com.bluetoya.taradiddle.feature.auth.dto.AuthRequest;
 import com.bluetoya.taradiddle.feature.auth.dto.SignInRequest;
 import com.bluetoya.taradiddle.feature.auth.entity.Auth;
 import com.bluetoya.taradiddle.feature.auth.repository.AuthRepository;
@@ -17,7 +17,7 @@ public class SignInValidator {
     private final AuthRepository authRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    public void validateLogin(LoginRequest request) {
+    public void validateLogin(AuthRequest request) {
         Auth auth = authRepository.findByUserId(request.userId())
             .orElseThrow(() -> new CustomException(AuthErrorCode.USER_ID_NOT_FOUND));
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,6 +5,14 @@ spring:
   data:
     mongodb:
       uri: mongodb://localhost:27017/taradiddle
+      host: localhost
+      port: 27017
+      database: taradiddle
+      pool-min-size: 0 # default
+      pool-max-size: 100 # default
+      connection-time-out: 10
+      max-wait-time: 30
+      read-time-out: 5
 jwt:
   access-token:
     secret-key: dGxmdGxya3Njb3hsZHhrZmtlbGVtZg==


### PR DESCRIPTION
refresh token 생성 및 검증 요소 추가

refresh token 생성
- 유저가 로그인할 때 refresh token도 같이 생성해서 응답 헤더에 넣어줌
- refresh token은 db에 저장

로그인 갱신
- access token 만료로 갱신 요청을 보내는 경우 사용
- refresh token을 db에서 찾아서 대조
- 동일하다면 access token과 refresh token 새로 생성해서 보내줌

mongo config 클래스 추가
- 앞으로 더 복잡한 쿼리가 추가될 거라 예상되고 조건문 쿼리 생성을 하려면 template가 필요해서 설치
- 추후 조정할 mongo client에 pool size, connection time out 등 설정 추가